### PR TITLE
Update NexmoMessage.php

### DIFF
--- a/NexmoMessage.php
+++ b/NexmoMessage.php
@@ -56,7 +56,7 @@ class NexmoMessage {
 	public $ssl_verify = false; // Verify Nexmo SSL before sending any message
 
 
-	function NexmoMessage ($api_key, $api_secret) {
+	public function __construct($api_key, $api_secret) {
 		$this->nx_key = $api_key;
 		$this->nx_secret = $api_secret;
 	}


### PR DESCRIPTION
Fixes deprecated class constructor method. See error message below:

ErrorException: Methods with the same name as their class will not be constructors in a future version of PHP; NexmoMessage has a deprecated constructor
